### PR TITLE
Fixes AbstractHorse duplication bug

### DIFF
--- a/fabric/src/main/java/io/github/mortuusars/horseman/fabric/HorsemanFabric.java
+++ b/fabric/src/main/java/io/github/mortuusars/horseman/fabric/HorsemanFabric.java
@@ -68,6 +68,7 @@ public class HorsemanFabric implements ModInitializer {
         ServerEntityEvents.ENTITY_UNLOAD.register((entity, world) -> {
             try {
                 if (entity instanceof AbstractHorse horse && world instanceof ServerLevel level) {
+                    if (horse.isRemoved()) return;
                     HorsemanServer.getSummoning().onHorseUnloaded(level, horse);
                 }
             } catch (Exception e) {


### PR DESCRIPTION
Bug is caused by entity being marked for removal through ``ServerEntityEvents.ENTITY_LOAD`` when calling ``<AbstractHorse>.discard()``, this means that when ``ServerEntityEvents.ENTITY_UNLOAD`` the entity may be marked for removal but there's no guard against that before executing the horse unload which modifies summoning storage.

closes #96 